### PR TITLE
sort packages case insensitively

### DIFF
--- a/lib/Dist/Surveyor/MakeCpan.pm
+++ b/lib/Dist/Surveyor/MakeCpan.pm
@@ -60,7 +60,7 @@ sub close {
         }
         $packages{$pkg} = $line;
     };
-    _writepkgs($self->{cpan_dir}, [ sort values %packages ] );
+    _writepkgs($self->{cpan_dir}, [ sort { lc $a cmp lc $b } values %packages ] );
 
 
 


### PR DESCRIPTION
02packages need to be sorted in case insensitive way, so that CPAN clients can match correctly.

PAUSE does the same.
https://github.com/andk/pause/blob/2daae9adb1bb229b2e1aaf3f269aed90ab0d20e8/lib/PAUSE/mldistwatch.pm#L635
